### PR TITLE
Updated jpgd.cpp

### DIFF
--- a/thirdparty/jpeg-compressor/jpgd.cpp
+++ b/thirdparty/jpeg-compressor/jpgd.cpp
@@ -1891,7 +1891,7 @@ namespace jpgd {
 		int y = m_image_y_size - m_total_lines_left;
 		int row = y & 15;
 
-		const int half_image_y_size = (m_image_y_size >> 1) - 1;
+		const int half_image_y_size = (m_image_y_size == 1) ? 0 : (m_image_y_size >> 1) - 1;
 
 		uint8* d0 = m_pScan_line_0;
 
@@ -1915,7 +1915,7 @@ namespace jpgd {
 		const int y0_base = (c_y0 & 7) * 8 + 256;
 		const int y1_base = (c_y1 & 7) * 8 + 256;
 
-		const int half_image_x_size = (m_image_x_size >> 1) - 1;
+		const int half_image_x_size = ( m_image_x_size == 1 ) ? 0 : ((m_image_x_size >> 1) - 1);
 
 		static const uint8_t s_muls[2][2][4] =
 		{


### PR DESCRIPTION
Just add an additional check for `half_image_y_size` and `half_image_x_size` for size of 1 pixel so that it's would be zero and not negative(-1) .

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
